### PR TITLE
Fixed not existing method replaced

### DIFF
--- a/poetry_babel_plugin/plugin.py
+++ b/poetry_babel_plugin/plugin.py
@@ -48,7 +48,7 @@ class BabelPlugin(ApplicationPlugin):
     ):
         if locales is None:
             # Detect locales by listing the directory
-            locale_paths = [(p.name, p) for p in dir_path.glob("*") if p.is_directory()]
+            locale_paths = [(p.name, p) for p in dir_path.glob("*") if p.is_dir()]
         else:
             locale_paths = [(locale, dir_path / locale) for locale in locales]
 


### PR DESCRIPTION
The method `is_directory` does not exist!   
The right method is `is_dir`.   
So if you build a project it fails when no locales are specified.
